### PR TITLE
Update modemd and location

### DIFF
--- a/config.go
+++ b/config.go
@@ -120,7 +120,15 @@ func (c *Config) getFileLock() error {
 }
 
 func interfaceToMap(value interface{}) (m map[string]interface{}, err error) {
-	err = mapstructure.Decode(value, &m)
+	decoderConfig := mapstructure.DecoderConfig{
+		DecodeHook: locationToMap,
+		Result:     &m,
+	}
+	decoder, err := mapstructure.NewDecoder(&decoderConfig)
+	if err != nil {
+		return nil, err
+	}
+	err = decoder.Decode(value)
 	return
 }
 

--- a/config.go
+++ b/config.go
@@ -49,6 +49,7 @@ var lockFilePath = func(configFile string) string {
 	return configFile + ".lock"
 }
 var lockTimeout = 10 * time.Second
+var mapStrInterfaceType = reflect.TypeOf(map[string]interface{}{})
 
 // New created a new config and loads files from the given directory
 func New(dir string) (*Config, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -146,7 +146,6 @@ func TestWriting(t *testing.T) {
 	require.NoError(t, conf2.Set(WindowsKey, w))
 	require.NoError(t, conf.Set(LocationKey, &l))
 	require.NoError(t, conf2.Set(TestHostsKey, &h))
-
 	conf, err = New(DefaultConfigDir)
 	require.NoError(t, err)
 	d2 := Device{}
@@ -160,7 +159,7 @@ func TestWriting(t *testing.T) {
 
 	require.Equal(t, d, d2)
 	require.Equal(t, w, w2)
-	require.Equal(t, l, l2)
+	equalLocation(t, l, l2)
 	require.Equal(t, h, h2)
 }
 
@@ -222,7 +221,16 @@ func randomLocation() Location {
 	return Location{
 		Accuracy:  float32(randSrc.Int63()),
 		Longitude: float32(randSrc.Int63()),
+		Timestamp: now(),
 	}
+}
+
+func equalLocation(t *testing.T, l1, l2 Location) {
+	require.Equal(t, l1.Accuracy, l2.Accuracy)
+	require.Equal(t, l1.Altitude, l2.Altitude)
+	require.Equal(t, l1.Latitude, l2.Latitude)
+	require.Equal(t, l1.Longitude, l2.Longitude)
+	require.Equal(t, l1.Timestamp.Unix(), l2.Timestamp.Unix())
 }
 
 func randomTestHosts() TestHosts {

--- a/location.go
+++ b/location.go
@@ -16,7 +16,12 @@
 
 package config
 
-import "time"
+import (
+	"reflect"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+)
 
 const LocationKey = "location"
 
@@ -33,5 +38,25 @@ func DefaultWindowLocation() Location {
 	return Location{
 		Latitude:  -43.5321,
 		Longitude: 172.6362,
+	}
+}
+
+func locationToMap(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+	if t != reflect.TypeOf(map[string]interface{}{}) {
+		return data, nil
+	}
+	switch f {
+	case reflect.TypeOf(&Location{}):
+		var m map[string]interface{}
+		err := mapstructure.Decode(data, &m)
+		m["Timestamp"] = data.(*Location).Timestamp.Truncate(time.Second)
+		return m, err
+	case reflect.TypeOf(Location{}):
+		var m map[string]interface{}
+		err := mapstructure.Decode(data, &m)
+		m["Timestamp"] = data.(Location).Timestamp.Truncate(time.Second)
+		return m, err
+	default:
+		return data, nil
 	}
 }

--- a/location.go
+++ b/location.go
@@ -42,17 +42,15 @@ func DefaultWindowLocation() Location {
 }
 
 func locationToMap(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
-	if t != reflect.TypeOf(map[string]interface{}{}) {
+	if t != mapStrInterfaceType {
 		return data, nil
 	}
 	switch f {
 	case reflect.TypeOf(&Location{}):
-		var m map[string]interface{}
-		err := mapstructure.Decode(data, &m)
-		m["Timestamp"] = data.(*Location).Timestamp.Truncate(time.Second)
-		return m, err
+		data = *(data.(*Location)) // follow the pointer
+		fallthrough
 	case reflect.TypeOf(Location{}):
-		var m map[string]interface{}
+		m := map[string]interface{}{}
 		err := mapstructure.Decode(data, &m)
 		m["Timestamp"] = data.(Location).Timestamp.Truncate(time.Second)
 		return m, err

--- a/modemd.go
+++ b/modemd.go
@@ -26,10 +26,10 @@ type Modemd struct {
 	FindModemTimeout  time.Duration `mapstructure:"find-modem-timeout"`
 	ConnectionTimeout time.Duration `mapstructure:"connection-timeout"`
 	RequestOnDuration time.Duration `mapstructure:"request-on-duration"`
-	Modems            []modem       `mapstructure:"modems"`
+	Modems            []Modem       `mapstructure:"modems"`
 }
 
-type modem struct {
+type Modem struct {
 	Name            string `mapstructure:"name"`
 	NetDev          string `mapstructure:"net-dev"`
 	VendorProductID string `mapstructure:"vendor-product-id"`
@@ -42,9 +42,9 @@ func DefaultModemd() Modemd {
 		FindModemTimeout:  time.Minute * 2,
 		ConnectionTimeout: time.Minute,
 		RequestOnDuration: time.Hour * 24,
-		Modems: []modem{
-			modem{Name: "Huawei 4G modem", NetDev: "eth1", VendorProductID: "12d1:14db"},
-			modem{Name: "Spark 3G modem", NetDev: "usb0", VendorProductID: "19d2:1405"},
+		Modems: []Modem{
+			Modem{Name: "Huawei 4G modem", NetDev: "eth1", VendorProductID: "12d1:14db"},
+			Modem{Name: "Spark 3G modem", NetDev: "usb0", VendorProductID: "19d2:1405"},
 		},
 	}
 }


### PR DESCRIPTION
When using `mapstructure.Decode` on a `Location` struct it would convert the `Timestamp` field to a `map[string]interface{}` because it was a embedded struct. This fixes that.
Handling of embedded structs in mapstructure: https://github.com/mitchellh/mapstructure/blob/master/mapstructure.go#L705  