### PR TITLE
Set from map

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,8 @@ release:
   name_template: '{{.Tag}}'
 
 builds:
-- goos:
+- id: cacophony-config-import
+  goos:
   - linux
   goarch:
   - arm
@@ -16,6 +17,16 @@ builds:
   main: ./cmd/cacophony-config-import
   ldflags: -s -w -X main.version={{.Version}}
   binary: cacophony-config-import
+- id: cacophony-config
+  goos:
+  - linux
+  goarch:
+  - arm
+  goarm:
+  - "7"
+  main: ./cmd/cacophony-config
+  ldflags: -s -w -X main.version={{.Version}}
+  binary: cacophony-config
 
 nfpms:
 - vendor: The Cacophony Project

--- a/audio.go
+++ b/audio.go
@@ -18,6 +18,14 @@ package config
 
 const AudioKey = "audio"
 
+func init() {
+	allSections[AudioKey] = section{
+		key:         AudioKey,
+		mapToStruct: makeMapToStruct(Audio{}),
+		validate:    noValidateFunc,
+	}
+}
+
 type Audio struct {
 	Dir           string `mapstructure:"directory"`
 	Card          int    `mapstructure:"card"`

--- a/audio.go
+++ b/audio.go
@@ -21,7 +21,7 @@ const AudioKey = "audio"
 func init() {
 	allSections[AudioKey] = section{
 		key:         AudioKey,
-		mapToStruct: makeMapToStruct(Audio{}),
+		mapToStruct: audioMapToStruct,
 		validate:    noValidateFunc,
 	}
 }
@@ -38,4 +38,12 @@ func DefaultAudio() Audio {
 		Card:          0,
 		VolumeControl: "PCM",
 	}
+}
+
+func audioMapToStruct(m map[string]interface{}) (interface{}, error) {
+	var s Audio
+	if err := decodeStructFromMap(&s, m, nil); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/battery.go
+++ b/battery.go
@@ -21,7 +21,7 @@ const BatteryKey = "battery"
 func init() {
 	allSections[BatteryKey] = section{
 		key:         BatteryKey,
-		mapToStruct: makeMapToStruct(Battery{}),
+		mapToStruct: batteryMapToStruct,
 		validate:    noValidateFunc,
 	}
 }
@@ -31,4 +31,12 @@ type Battery struct {
 	NoBattery             uint16 `mapstructure:"no-battery-reading"`
 	LowBattery            uint16 `mapstructure:"low-battery-reading"`
 	FullBattery           uint16 `mapstructure:"full-battery-reading"`
+}
+
+func batteryMapToStruct(m map[string]interface{}) (interface{}, error) {
+	var s Battery
+	if err := decodeStructFromMap(&s, m, nil); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/battery.go
+++ b/battery.go
@@ -18,6 +18,14 @@ package config
 
 const BatteryKey = "battery"
 
+func init() {
+	allSections[BatteryKey] = section{
+		key:         BatteryKey,
+		mapToStruct: makeMapToStruct(Battery{}),
+		validate:    noValidateFunc,
+	}
+}
+
 type Battery struct {
 	EnableVoltageReadings bool   `mapstructure:"enable-voltage-readings"`
 	NoBattery             uint16 `mapstructure:"no-battery-reading"`

--- a/cmd/cacophony-config-import/main.go
+++ b/cmd/cacophony-config-import/main.go
@@ -230,7 +230,7 @@ type motionConfig struct {
 }
 
 type throttlerConfig struct {
-	ApplyThrottling bool          `yaml:"apply-throttling" mapstructure:"thermal-throttler.active"`
+	ApplyThrottling bool          `yaml:"apply-throttling" mapstructure:"thermal-throttler.activate"`
 	BucketSize      time.Duration `yaml:"bucket-size" mapstructure:"thermal-throttler.bucket-size"`
 	MinRefill       time.Duration `yaml:"min-refill" mapstructure:"thermal-throttler.min-refill"`
 }

--- a/cmd/cacophony-config/main.go
+++ b/cmd/cacophony-config/main.go
@@ -32,10 +32,22 @@ func runMain() error {
 		return err
 	}
 
+	sections := map[string]int{}
 	for _, s := range settings {
 		if err := conf.SetField(s.section, s.field, s.value); err != nil {
 			return err
 		}
+		if _, ok := sections[s.section]; !ok {
+			sections[s.section] = 0
+		}
+	}
+
+	for section, _ := range sections {
+		raw := map[string]interface{}{}
+		if err := conf.Unmarshal(section, &raw); err != nil {
+			return err
+		}
+		log.Printf("section: '%s', values: '%s'", section, raw)
 	}
 
 	return nil

--- a/cmd/cacophony-config/main.go
+++ b/cmd/cacophony-config/main.go
@@ -85,14 +85,12 @@ func writeNewSettings(args *Args) error {
 	}
 	conf.AutoWrite = false // Only write if there were no errors in writing all the settings
 
-	sections := map[string]int{}
+	sections := map[string]struct{}{}
 	for _, s := range settings {
 		if err := conf.SetField(s.section, s.field, s.value); err != nil {
 			return err
 		}
-		if _, ok := sections[s.section]; !ok {
-			sections[s.section] = 0
-		}
+		sections[s.section] = struct{}{}
 	}
 	if err := conf.Write(); err != nil {
 		return err

--- a/cmd/cacophony-config/main.go
+++ b/cmd/cacophony-config/main.go
@@ -31,6 +31,7 @@ func runMain() error {
 	if err != nil {
 		return err
 	}
+	conf.AutoWrite = false // Only write if there were no errors in writing all the settings
 
 	sections := map[string]int{}
 	for _, s := range settings {
@@ -40,6 +41,9 @@ func runMain() error {
 		if _, ok := sections[s.section]; !ok {
 			sections[s.section] = 0
 		}
+	}
+	if err := conf.Write(); err != nil {
+		return err
 	}
 
 	for section, _ := range sections {

--- a/cmd/cacophony-config/main.go
+++ b/cmd/cacophony-config/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	config "github.com/TheCacophonyProject/go-config"
+)
+
+var version = "<not set>"
+
+func main() {
+	if err := runMain(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func runMain() error {
+	log.SetFlags(0)
+	log.Printf("running version: %s", version)
+
+	settings, err := getNewSettings(os.Args[1:])
+	if err != nil {
+		return err
+	}
+	log.Printf("new settings: %+v", settings)
+
+	conf, err := config.New(config.DefaultConfigDir)
+	if err != nil {
+		return err
+	}
+
+	for _, s := range settings {
+		if err := conf.SetField(s.section, s.field, s.value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type setting struct {
+	section string
+	field   string
+	value   string
+}
+
+func getNewSettings(args []string) ([]setting, error) {
+	settings := []setting{}
+	for _, arg := range args {
+		spl := strings.Split(arg, "=")
+		if len(spl) != 2 {
+			return nil, fmt.Errorf("'%s' should contain one '='", arg)
+		}
+		key := spl[0]
+		val := spl[1]
+
+		spl = strings.Split(key, ".")
+		if len(spl) != 2 {
+			return nil, fmt.Errorf("'%s' should contain one '.' Nested fields are not supported yet", arg)
+		}
+		settings = append(settings, setting{
+			section: spl[0],
+			field:   spl[1],
+			value:   val,
+		})
+	}
+	return settings, nil
+}

--- a/cmd/cacophony-config/main.go
+++ b/cmd/cacophony-config/main.go
@@ -3,13 +3,30 @@ package main
 import (
 	"fmt"
 	"log"
-	"os"
 	"strings"
 
 	config "github.com/TheCacophonyProject/go-config"
+	"github.com/alexflint/go-arg"
 )
 
 var version = "<not set>"
+
+type Args struct {
+	ConfigDir string   `arg:"-c,--config" help:"path to configuration directory"`
+	Write     bool     `arg:"-w,--write" help:"write to config file"`
+	Input     []string `arg:"positional"`
+}
+
+func (Args) Version() string {
+	return version
+}
+
+func procArgs() Args {
+	var args Args
+	args.ConfigDir = config.DefaultConfigDir
+	arg.MustParse(&args)
+	return args
+}
 
 func main() {
 	if err := runMain(); err != nil {
@@ -18,16 +35,30 @@ func main() {
 }
 
 func runMain() error {
+	args := procArgs()
 	log.SetFlags(0)
 	log.Printf("running version: %s", version)
 
-	settings, err := getNewSettings(os.Args[1:])
+	if args.Write {
+		return writeNewSettings(&args)
+	}
+	return nil
+}
+
+type setting struct {
+	section string
+	field   string
+	value   string
+}
+
+func writeNewSettings(args *Args) error {
+	settings, err := getNewSettings(args.Input)
 	if err != nil {
 		return err
 	}
 	log.Printf("new settings: %+v", settings)
 
-	conf, err := config.New(config.DefaultConfigDir)
+	conf, err := config.New(args.ConfigDir)
 	if err != nil {
 		return err
 	}
@@ -55,12 +86,6 @@ func runMain() error {
 	}
 
 	return nil
-}
-
-type setting struct {
-	section string
-	field   string
-	value   string
 }
 
 func getNewSettings(args []string) ([]setting, error) {

--- a/cmd/cacophony-config/main.go
+++ b/cmd/cacophony-config/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -14,6 +15,7 @@ var version = "<not set>"
 type Args struct {
 	ConfigDir string   `arg:"-c,--config" help:"path to configuration directory"`
 	Write     bool     `arg:"-w,--write" help:"write to config file"`
+	Read      bool     `arg:"-r,--read" help:"read from the config file"`
 	Input     []string `arg:"positional"`
 }
 
@@ -41,6 +43,25 @@ func runMain() error {
 
 	if args.Write {
 		return writeNewSettings(&args)
+	}
+	if args.Read {
+		return readConfig(&args)
+	}
+	return errors.New("no valid arguments given")
+}
+
+func readConfig(args *Args) error {
+	conf, err := config.New(args.ConfigDir)
+	if err != nil {
+		return err
+	}
+
+	for _, section := range args.Input {
+		var m map[string]interface{}
+		if err := conf.Unmarshal(section, &m); err != nil {
+			return err
+		}
+		log.Printf("section: '%s', values: '%s'", section, m)
 	}
 	return nil
 }

--- a/cmd/cacophony-config/main_test.go
+++ b/cmd/cacophony-config/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseArgs(t *testing.T) {
+	args := []string{"cat.foo=bar", "bar.foo=cat"}
+	expected := []setting{
+		setting{section: "cat", field: "foo", value: "bar"},
+		setting{section: "bar", field: "foo", value: "cat"},
+	}
+	sections, err := getNewSettings(args)
+	require.NoError(t, err)
+	require.Equal(t, expected, sections)
+}
+
+func TestBadArgs(t *testing.T) {
+	_, err := getNewSettings([]string{"cat.foobar"})
+	require.Error(t, err)
+
+	_, err = getNewSettings([]string{"catfoo=bar"})
+	require.Error(t, err)
+
+	_, err = getNewSettings([]string{"cat.dog=foo=bar"})
+	require.Error(t, err)
+
+	_, err = getNewSettings([]string{"cat.dog.foo=bar"})
+	require.Error(t, err)
+}

--- a/config.go
+++ b/config.go
@@ -124,16 +124,25 @@ func (c *Config) SetFromMap(sectionKey string, newConfig map[string]interface{})
 		return err
 	}
 
-	section, ok := allSections[sectionKey]
-	if !ok {
-		return fmt.Errorf("no section found called '%s'", sectionKey)
-	}
+	section := allSections[sectionKey]
 	newStruct, err := section.mapToStruct(newConfig)
 	if err != nil {
 		return err
 	}
 
 	return c.Set(sectionKey, newStruct)
+}
+
+func (c *Config) SetField(sectionKey, valueKey, value string) error {
+	if !checkIfSectionKey(sectionKey) {
+		return notSectionKeyError(sectionKey)
+	}
+
+	section := allSections[sectionKey]
+	s := map[string]interface{}{}
+	c.Unmarshal(section.key, &s)
+	s[valueKey] = value
+	return c.SetFromMap(sectionKey, s)
 }
 
 func (c *Config) Update() error {
@@ -213,7 +222,7 @@ func (c *Config) setStruct(key string, value interface{}) error {
 }
 
 func notSectionKeyError(key string) error {
-	return fmt.Errorf("'%s' is no a key for a section", key)
+	return fmt.Errorf("'%s' is not a key for a section", key)
 }
 
 func checkIfSectionKey(key string) bool {

--- a/config.go
+++ b/config.go
@@ -147,6 +147,7 @@ func (c *Config) SetField(sectionKey, valueKey, value string) error {
 	s := map[string]interface{}{}
 	c.Unmarshal(section.key, &s)
 	s[valueKey] = value
+	delete(s, "updated")
 	return c.SetFromMap(sectionKey, s)
 }
 
@@ -267,6 +268,7 @@ func decodeStructFromMap(s interface{}, m map[string]interface{}, decodeHook int
 		DecodeHook:       mapstructure.ComposeDecodeHookFunc(stringToDuration, stringToTime),
 		Result:           s,
 		WeaklyTypedInput: true,
+		ErrorUnused:      true,
 	}
 	if decodeHook != nil {
 		decoderConfig.DecodeHook = mapstructure.ComposeDecodeHookFunc(decodeHook, decoderConfig.DecodeHook)

--- a/config_test.go
+++ b/config_test.go
@@ -209,9 +209,8 @@ func TestSettingUpdated(t *testing.T) {
 	require.Equal(t, conf.Get(DeviceKey+".updated"), now())
 }
 
-func TestMapToStruct(t *testing.T) {
+func TestMapToLocation(t *testing.T) {
 	defer newFs(t, "")()
-
 	conf, err := New(DefaultConfigDir)
 	require.NoError(t, err)
 
@@ -228,7 +227,12 @@ func TestMapToStruct(t *testing.T) {
 	require.NoError(t, conf.SetFromMap(LocationKey, locationMap))
 	require.NoError(t, conf.Unmarshal(LocationKey, &location))
 	equalLocation(t, locationExpected, location)
+}
 
+func TestMapToAudio(t *testing.T) {
+	defer newFs(t, "")()
+	conf, err := New(DefaultConfigDir)
+	require.NoError(t, err)
 	audioMap := map[string]interface{}{
 		"directory":      "/audio/directory",
 		"card":           "4",
@@ -240,15 +244,30 @@ func TestMapToStruct(t *testing.T) {
 		VolumeControl: "audio volume control",
 	}
 	checkWritingMap(t, AudioKey, &Audio{}, &audioExpected, audioMap, conf)
+}
 
+func TestMapToBattery(t *testing.T) {
+	defer newFs(t, "")()
+	conf, err := New(DefaultConfigDir)
+	require.NoError(t, err)
 	batteryMap := map[string]interface{}{"enable-voltage-readings": "true"}
 	batteryExpected := Battery{EnableVoltageReadings: true}
 	checkWritingMap(t, BatteryKey, &Battery{}, &batteryExpected, batteryMap, conf)
+}
 
+func TestMapToDevice(t *testing.T) {
+	defer newFs(t, "")()
+	conf, err := New(DefaultConfigDir)
+	require.NoError(t, err)
 	deviceMap := map[string]interface{}{"Group": "a-group"}
 	deviceExpected := Device{Group: "a-group"}
 	checkWritingMap(t, DeviceKey, &Device{}, &deviceExpected, deviceMap, conf)
+}
 
+func TestMapToModemd(t *testing.T) {
+	defer newFs(t, "")()
+	conf, err := New(DefaultConfigDir)
+	require.NoError(t, err)
 	modemdMap := map[string]interface{}{
 		"test-interval": "10m4s",
 		"modems": []map[string]interface{}{

--- a/config_test.go
+++ b/config_test.go
@@ -276,6 +276,8 @@ func TestSetField(t *testing.T) {
 	require.NoError(t, conf.Set(AudioKey, audio))
 
 	require.NoError(t, conf.SetField(AudioKey, "card", "5"))
+	require.Error(t, conf.SetField(AudioKey, "not-a-key", "5"))
+
 	var audio2 Audio
 	require.NoError(t, conf.Unmarshal(AudioKey, &audio2))
 

--- a/config_test.go
+++ b/config_test.go
@@ -213,6 +213,7 @@ func TestSettingUpdated(t *testing.T) {
 }
 
 func TestMapToLocation(t *testing.T) {
+	defer newFs(t, "")()
 	m := map[string]interface{}{
 		"latitude":  "123.321",
 		"timestamp": now().Truncate(1).String(),
@@ -220,6 +221,15 @@ func TestMapToLocation(t *testing.T) {
 	l, err := mapToLocation(m)
 	require.NoError(t, err)
 	log.Printf("%+v", l)
+
+	conf, err := New(DefaultConfigDir)
+	require.NoError(t, err)
+
+	require.NoError(t, conf.SetFromMap(LocationKey, m))
+
+	var l2 Location
+	require.NoError(t, conf.Unmarshal(LocationKey, &l2))
+	equalLocation(t, l.(Location), l2)
 }
 
 func newFs(t *testing.T, configFile string) func() {

--- a/config_test.go
+++ b/config_test.go
@@ -207,20 +207,16 @@ func TestSettingUpdated(t *testing.T) {
 
 	require.NoError(t, conf.Set(DeviceKey, randomDevice()))
 	require.Equal(t, conf.Get(DeviceKey+".updated"), now())
-
-	require.NoError(t, conf.Set(DeviceKey+".name", randString(10)))
-	require.Equal(t, conf.Get(DeviceKey+".updated"), now())
 }
 
 func TestMapToLocation(t *testing.T) {
 	defer newFs(t, "")()
 	m := map[string]interface{}{
 		"latitude":  "123.321",
-		"timestamp": now().Truncate(1).String(),
+		"timestamp": now().Format(TimeFormat),
 	}
 	l, err := mapToLocation(m)
 	require.NoError(t, err)
-	log.Printf("%+v", l)
 
 	conf, err := New(DefaultConfigDir)
 	require.NoError(t, err)

--- a/config_test.go
+++ b/config_test.go
@@ -264,7 +264,36 @@ func TestMapToStruct(t *testing.T) {
 	checkWritingMap(t, ModemdKey, &Modemd{}, &modemdExpected, modemdMap, conf)
 }
 
-func checkWritingMap(t *testing.T, key string, s, expected interface{}, m map[string]interface{}, conf *Config) {
+func TestSetField(t *testing.T) {
+	defer newFs(t, "")()
+	conf, err := New(DefaultConfigDir)
+	require.NoError(t, err)
+	audio := Audio{
+		Dir:           "/audio/directory",
+		Card:          4,
+		VolumeControl: "audio volume control",
+	}
+	require.NoError(t, conf.Set(AudioKey, audio))
+
+	require.NoError(t, conf.SetField(AudioKey, "card", "5"))
+	var audio2 Audio
+	require.NoError(t, conf.Unmarshal(AudioKey, &audio2))
+
+	audioExpected := Audio{
+		Dir:           "/audio/directory",
+		Card:          5,
+		VolumeControl: "audio volume control",
+	}
+
+	require.Equal(t, audioExpected, audio2)
+}
+
+func checkWritingMap(
+	t *testing.T,
+	key string,
+	s, expected interface{},
+	m map[string]interface{},
+	conf *Config) {
 	require.NoError(t, conf.SetFromMap(key, m))
 	require.NoError(t, conf.Unmarshal(key, s))
 	require.Equal(t, expected, s)

--- a/config_test.go
+++ b/config_test.go
@@ -212,6 +212,16 @@ func TestSettingUpdated(t *testing.T) {
 	require.Equal(t, conf.Get(DeviceKey+".updated"), now())
 }
 
+func TestMapToLocation(t *testing.T) {
+	m := map[string]interface{}{
+		"latitude":  "123.321",
+		"timestamp": now().Truncate(1).String(),
+	}
+	l, err := mapToLocation(m)
+	require.NoError(t, err)
+	log.Printf("%+v", l)
+}
+
 func newFs(t *testing.T, configFile string) func() {
 	fs := afero.NewMemMapFs()
 	SetFs(fs)

--- a/device.go
+++ b/device.go
@@ -21,7 +21,7 @@ const DeviceKey = "device"
 func init() {
 	allSections[DeviceKey] = section{
 		key:         DeviceKey,
-		mapToStruct: makeMapToStruct(Device{}),
+		mapToStruct: deviceMapToStruct,
 		validate:    noValidateFunc,
 	}
 }
@@ -31,4 +31,12 @@ type Device struct {
 	ID     int
 	Name   string
 	Server string
+}
+
+func deviceMapToStruct(m map[string]interface{}) (interface{}, error) {
+	var s Device
+	if err := decodeStructFromMap(&s, m, nil); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/device.go
+++ b/device.go
@@ -18,6 +18,14 @@ package config
 
 const DeviceKey = "device"
 
+func init() {
+	allSections[DeviceKey] = section{
+		key:         DeviceKey,
+		mapToStruct: makeMapToStruct(Device{}),
+		validate:    noValidateFunc,
+	}
+}
+
 type Device struct {
 	Group  string
 	ID     int

--- a/gpio.go
+++ b/gpio.go
@@ -18,6 +18,14 @@ package config
 
 const GPIOKey = "gpio"
 
+func init() {
+	allSections[GPIOKey] = section{
+		key:         GPIOKey,
+		mapToStruct: makeMapToStruct(GPIO{}),
+		validate:    noValidateFunc,
+	}
+}
+
 type GPIO struct {
 	ThermalCameraPower string `mapstructure:"thermal-camera-power"`
 	ModemPower         string `mapstructure:"modem-power"`

--- a/gpio.go
+++ b/gpio.go
@@ -21,7 +21,7 @@ const GPIOKey = "gpio"
 func init() {
 	allSections[GPIOKey] = section{
 		key:         GPIOKey,
-		mapToStruct: makeMapToStruct(GPIO{}),
+		mapToStruct: gpioMapToStruct,
 		validate:    noValidateFunc,
 	}
 }
@@ -36,4 +36,12 @@ func DefaultGPIO() GPIO {
 		ThermalCameraPower: "GPIO23",
 		ModemPower:         "GPIO22",
 	}
+}
+
+func gpioMapToStruct(m map[string]interface{}) (interface{}, error) {
+	var s GPIO
+	if err := decodeStructFromMap(&s, m, nil); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/lepton.go
+++ b/lepton.go
@@ -18,6 +18,14 @@ package config
 
 const LeptonKey = "lepton"
 
+func init() {
+	allSections[LeptonKey] = section{
+		key:         LeptonKey,
+		mapToStruct: makeMapToStruct(Lepton{}),
+		validate:    noValidateFunc,
+	}
+}
+
 type Lepton struct {
 	SPISpeed    int64  `mapstructure:"spi-speed"`
 	FrameOutput string `mapstructure:"frame-output"`

--- a/lepton.go
+++ b/lepton.go
@@ -21,7 +21,7 @@ const LeptonKey = "lepton"
 func init() {
 	allSections[LeptonKey] = section{
 		key:         LeptonKey,
-		mapToStruct: makeMapToStruct(Lepton{}),
+		mapToStruct: leptonMapToStruct,
 		validate:    noValidateFunc,
 	}
 }
@@ -36,4 +36,12 @@ func DefaultLepton() Lepton {
 		SPISpeed:    2000000,
 		FrameOutput: "/var/run/lepton-frames",
 	}
+}
+
+func leptonMapToStruct(m map[string]interface{}) (interface{}, error) {
+	var s Lepton
+	if err := decodeStructFromMap(&s, m, nil); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/location.go
+++ b/location.go
@@ -26,10 +26,10 @@ import (
 func init() {
 	allSections[LocationKey] = section{
 		key:         LocationKey,
-		structToMap: locationToMap,
 		mapToStruct: mapToLocation,
 		validate:    validateLocation,
 	}
+	allSectionDecodeHookFuncs = append(allSectionDecodeHookFuncs, locationToMap)
 }
 
 const LocationKey = "location"
@@ -68,36 +68,18 @@ func locationToMap(f reflect.Type, t reflect.Type, data interface{}) (interface{
 	}
 }
 
-func stringToTime(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
-	if t != reflect.TypeOf(time.Time{}) {
-		return data, nil
-	}
-	switch f {
-	case reflect.TypeOf(""):
-		layout := "2006-01-02 15:04:05.000000000 -0700 MST"
-		return time.Parse(layout, data.(string))
-	}
-	return data, nil
-}
-
 func mapToLocation(m map[string]interface{}) (interface{}, error) {
 	var l Location
-	decoderConfig := mapstructure.DecoderConfig{
-		DecodeHook:       stringToTime,
-		Result:           &l,
-		WeaklyTypedInput: true,
-	}
-	decoder, err := mapstructure.NewDecoder(&decoderConfig)
-	if err != nil {
+	if err := decodeStructFromMap(&l, m, stringToTime); err != nil {
 		return nil, err
 	}
-
-	if err := decoder.Decode(m); err != nil {
+	if err := validateLocation(&l); err != nil {
 		return nil, err
 	}
 	return l, nil
 }
 
-func validateLocation(l interface{}) bool {
-	return true
+//TODO
+func validateLocation(l interface{}) error {
+	return nil
 }

--- a/modemd.go
+++ b/modemd.go
@@ -20,6 +20,14 @@ import "time"
 
 const ModemdKey = "modemd"
 
+func init() {
+	allSections[ModemdKey] = section{
+		key:         ModemdKey,
+		mapToStruct: makeMapToStruct(Modemd{}),
+		validate:    noValidateFunc,
+	}
+}
+
 type Modemd struct {
 	TestInterval      time.Duration `mapstructure:"test-interval"`
 	InitialOnDuration time.Duration `mapstructure:"initial-on-duration"`

--- a/modemd.go
+++ b/modemd.go
@@ -16,16 +16,22 @@
 
 package config
 
-import "time"
+import (
+	"reflect"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+)
 
 const ModemdKey = "modemd"
 
 func init() {
 	allSections[ModemdKey] = section{
 		key:         ModemdKey,
-		mapToStruct: makeMapToStruct(Modemd{}),
+		mapToStruct: modemdMapToStruct,
 		validate:    noValidateFunc,
 	}
+	allSectionDecodeHookFuncs = append(allSectionDecodeHookFuncs, modemdToMap)
 }
 
 type Modemd struct {
@@ -55,4 +61,36 @@ func DefaultModemd() Modemd {
 			Modem{Name: "Spark 3G modem", NetDev: "usb0", VendorProductID: "19d2:1405"},
 		},
 	}
+}
+
+func modemdToMap(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+	if t != mapStrInterfaceType {
+		return data, nil
+	}
+	switch f {
+	case reflect.TypeOf(&Modemd{}):
+		data = *(data.(*Modemd)) // follow the pointer
+		fallthrough
+	case reflect.TypeOf(Modemd{}):
+		m := map[string]interface{}{}
+		if err := mapstructure.Decode(data, &m); err != nil {
+			return nil, err
+		}
+		modems := []map[string]interface{}{}
+		if err := mapstructure.Decode(data.(Modemd).Modems, &modems); err != nil {
+			return nil, err
+		}
+		m["modems"] = modems
+		return m, nil
+	default:
+		return data, nil
+	}
+}
+
+func modemdMapToStruct(m map[string]interface{}) (interface{}, error) {
+	var s Modemd
+	if err := decodeStructFromMap(&s, m, nil); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/ports.go
+++ b/ports.go
@@ -18,6 +18,14 @@ package config
 
 const PortsKey = "ports"
 
+func init() {
+	allSections[PortsKey] = section{
+		key:         PortsKey,
+		mapToStruct: makeMapToStruct(Ports{}),
+		validate:    noValidateFunc,
+	}
+}
+
 type Ports struct {
 	Managementd int
 }

--- a/ports.go
+++ b/ports.go
@@ -21,7 +21,7 @@ const PortsKey = "ports"
 func init() {
 	allSections[PortsKey] = section{
 		key:         PortsKey,
-		mapToStruct: makeMapToStruct(Ports{}),
+		mapToStruct: portsMapToStruct,
 		validate:    noValidateFunc,
 	}
 }
@@ -35,4 +35,11 @@ func DefaultPorts() Ports {
 	return Ports{
 		Managementd: 80,
 	}
+}
+func portsMapToStruct(m map[string]interface{}) (interface{}, error) {
+	var s Ports
+	if err := decodeStructFromMap(&s, m, nil); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/secrets.go
+++ b/secrets.go
@@ -21,11 +21,19 @@ const SecretsKey = "secrets"
 func init() {
 	allSections[SecretsKey] = section{
 		key:         SecretsKey,
-		mapToStruct: makeMapToStruct(Secrets{}),
+		mapToStruct: secretsMapToStruct,
 		validate:    noValidateFunc,
 	}
 }
 
 type Secrets struct {
 	DevicePassword string `mapstructure:"device-password"`
+}
+
+func secretsMapToStruct(m map[string]interface{}) (interface{}, error) {
+	var s Secrets
+	if err := decodeStructFromMap(&s, m, nil); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/secrets.go
+++ b/secrets.go
@@ -18,6 +18,14 @@ package config
 
 const SecretsKey = "secrets"
 
+func init() {
+	allSections[SecretsKey] = section{
+		key:         SecretsKey,
+		mapToStruct: makeMapToStruct(Secrets{}),
+		validate:    noValidateFunc,
+	}
+}
+
 type Secrets struct {
 	DevicePassword string `mapstructure:"device-password"`
 }

--- a/test-hosts.go
+++ b/test-hosts.go
@@ -23,7 +23,7 @@ const TestHostsKey = "test-hosts"
 func init() {
 	allSections[TestHostsKey] = section{
 		key:         TestHostsKey,
-		mapToStruct: makeMapToStruct(TestHosts{}),
+		mapToStruct: testHostsMapToStruct,
 		validate:    noValidateFunc,
 	}
 }
@@ -40,4 +40,12 @@ func DefaultTestHosts() TestHosts {
 		PingWaitTime: time.Second * 30,
 		PingRetries:  5,
 	}
+}
+
+func testHostsMapToStruct(m map[string]interface{}) (interface{}, error) {
+	var s TestHosts
+	if err := decodeStructFromMap(&s, m, nil); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/test-hosts.go
+++ b/test-hosts.go
@@ -20,6 +20,14 @@ import "time"
 
 const TestHostsKey = "test-hosts"
 
+func init() {
+	allSections[TestHostsKey] = section{
+		key:         TestHostsKey,
+		mapToStruct: makeMapToStruct(TestHosts{}),
+		validate:    noValidateFunc,
+	}
+}
+
 type TestHosts struct {
 	URLs         []string
 	PingWaitTime time.Duration `mapstructure:"ping-wait-time"`

--- a/thermal-motion.go
+++ b/thermal-motion.go
@@ -21,7 +21,7 @@ const ThermalMotionKey = "thermal-motion"
 func init() {
 	allSections[ThermalMotionKey] = section{
 		key:         ThermalMotionKey,
-		mapToStruct: makeMapToStruct(ThermalMotion{}),
+		mapToStruct: thermalMotionMapToStruct,
 		validate:    noValidateFunc,
 	}
 }
@@ -52,4 +52,12 @@ func DefaultThermalMotion() ThermalMotion {
 		WarmerOnly:       true,
 		EdgePixels:       1,
 	}
+}
+
+func thermalMotionMapToStruct(m map[string]interface{}) (interface{}, error) {
+	var s ThermalMotion
+	if err := decodeStructFromMap(&s, m, nil); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/thermal-motion.go
+++ b/thermal-motion.go
@@ -18,6 +18,14 @@ package config
 
 const ThermalMotionKey = "thermal-motion"
 
+func init() {
+	allSections[ThermalMotionKey] = section{
+		key:         ThermalMotionKey,
+		mapToStruct: makeMapToStruct(ThermalMotion{}),
+		validate:    noValidateFunc,
+	}
+}
+
 type ThermalMotion struct {
 	DynamicThreshold bool   `mapstructure:"min-secs"`
 	TempThresh       uint16 `mapstructure:"temp-thresh"`

--- a/thermal-recorder.go
+++ b/thermal-recorder.go
@@ -18,6 +18,14 @@ package config
 
 const ThermalRecorderKey = "thermal-recorder"
 
+func init() {
+	allSections[ThermalRecorderKey] = section{
+		key:         ThermalRecorderKey,
+		mapToStruct: makeMapToStruct(ThermalRecorder{}),
+		validate:    noValidateFunc,
+	}
+}
+
 type ThermalRecorder struct {
 	OutputDir      string `mapstructure:"output-dir"`
 	MinDiskSpaceMB uint64 `mapstructure:"min-disk-space-mb"`

--- a/thermal-recorder.go
+++ b/thermal-recorder.go
@@ -21,7 +21,7 @@ const ThermalRecorderKey = "thermal-recorder"
 func init() {
 	allSections[ThermalRecorderKey] = section{
 		key:         ThermalRecorderKey,
-		mapToStruct: makeMapToStruct(ThermalRecorder{}),
+		mapToStruct: thermalRecorderMapToStruct,
 		validate:    noValidateFunc,
 	}
 }
@@ -42,4 +42,12 @@ func DefaultThermalRecorder() ThermalRecorder {
 		MinDiskSpaceMB: 200,
 		OutputDir:      "/var/spool/cptv",
 	}
+}
+
+func thermalRecorderMapToStruct(m map[string]interface{}) (interface{}, error) {
+	var s ThermalRecorder
+	if err := decodeStructFromMap(&s, m, nil); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/thermal-throttler.go
+++ b/thermal-throttler.go
@@ -20,6 +20,14 @@ import "time"
 
 const ThermalThrottlerKey = "thermal-throttler"
 
+func init() {
+	allSections[ThermalThrottlerKey] = section{
+		key:         ThermalThrottlerKey,
+		mapToStruct: makeMapToStruct(ThermalThrottler{}),
+		validate:    noValidateFunc,
+	}
+}
+
 type ThermalThrottler struct {
 	Activate   bool
 	BucketSize time.Duration `mapstructure:"bucket-size"`

--- a/thermal-throttler.go
+++ b/thermal-throttler.go
@@ -23,7 +23,7 @@ const ThermalThrottlerKey = "thermal-throttler"
 func init() {
 	allSections[ThermalThrottlerKey] = section{
 		key:         ThermalThrottlerKey,
-		mapToStruct: makeMapToStruct(ThermalThrottler{}),
+		mapToStruct: thermalThrottlerMapToStruct,
 		validate:    noValidateFunc,
 	}
 }
@@ -41,4 +41,12 @@ func DefaultThermalThrottler() ThermalThrottler {
 		BucketSize: 10 * time.Minute,
 		MinRefill:  10 * time.Minute,
 	}
+}
+
+func thermalThrottlerMapToStruct(m map[string]interface{}) (interface{}, error) {
+	var s ThermalThrottler
+	if err := decodeStructFromMap(&s, m, nil); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/windows.go
+++ b/windows.go
@@ -19,7 +19,7 @@ package config
 func init() {
 	allSections[WindowsKey] = section{
 		key:         WindowsKey,
-		mapToStruct: makeMapToStruct(Windows{}),
+		mapToStruct: windowsMapToStruct,
 		validate:    noValidateFunc,
 	}
 }
@@ -46,20 +46,10 @@ func noValidateFunc(s interface{}) error {
 	return nil
 }
 
-func makeMapToStruct(s interface{}) func(map[string]interface{}) (interface{}, error) {
-	return func(m map[string]interface{}) (interface{}, error) {
-		if err := decodeStructFromMap(&s, m, stringToTime); err != nil {
-			return nil, err
-		}
-		return s, nil
+func windowsMapToStruct(m map[string]interface{}) (interface{}, error) {
+	var s Windows
+	if err := decodeStructFromMap(&s, m, nil); err != nil {
+		return nil, err
 	}
-}
-
-func makeStructToMap(s interface{}) func(map[string]interface{}) (interface{}, error) {
-	return func(m map[string]interface{}) (interface{}, error) {
-		if err := decodeStructFromMap(&s, m, stringToTime); err != nil {
-			return nil, err
-		}
-		return s, nil
-	}
+	return s, nil
 }

--- a/windows.go
+++ b/windows.go
@@ -16,6 +16,14 @@
 
 package config
 
+func init() {
+	allSections[WindowsKey] = section{
+		key:         WindowsKey,
+		mapToStruct: makeMapToStruct(Windows{}),
+		validate:    noValidateFunc,
+	}
+}
+
 const WindowsKey = "windows"
 
 type Windows struct {
@@ -31,5 +39,27 @@ func DefaultWindows() Windows {
 		StopRecording:  "+30m",
 		PowerOn:        "12:00",
 		PowerOff:       "12:00",
+	}
+}
+
+func noValidateFunc(s interface{}) error {
+	return nil
+}
+
+func makeMapToStruct(s interface{}) func(map[string]interface{}) (interface{}, error) {
+	return func(m map[string]interface{}) (interface{}, error) {
+		if err := decodeStructFromMap(&s, m, stringToTime); err != nil {
+			return nil, err
+		}
+		return s, nil
+	}
+}
+
+func makeStructToMap(s interface{}) func(map[string]interface{}) (interface{}, error) {
+	return func(m map[string]interface{}) (interface{}, error) {
+		if err := decodeStructFromMap(&s, m, stringToTime); err != nil {
+			return nil, err
+		}
+		return s, nil
 	}
 }


### PR DESCRIPTION
- Added command line tool for writing to the config file.
- Command example `cacophony-config section.key=value section2.key2=value2`
- When setting multiple fields the changes will only be written to file if there are no errors.
- When setting a config field it will error if:
  - Can't convert value to the correct type ("foo" to bool)
  - Section is not found
  - Key is not found in that section
- After writing to the config to file all the sections that were written to will be printed out.