### PR TITLE
Change goreleaser project name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-project_name: cacophony-config
+project_name: go-config
 
 release:
   github:

--- a/cmd/cacophony-config-import/main.go
+++ b/cmd/cacophony-config-import/main.go
@@ -42,9 +42,9 @@ func main() {
 }
 
 func runMain() error {
+	args := procArgs()
 	log.SetFlags(0)
 	log.Printf("running version: %s", version)
-	args := procArgs()
 	v := viper.New()
 	configFile := path.Join(args.Dir, "config.toml")
 	if _, err := os.Stat(configFile); err == nil && !args.Force {


### PR DESCRIPTION
The github name and goreleaser project name need to match for the salt install script to work.