### PR TITLE
Add unset key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.12.x"
+  - "1.13.x"
 
 script:
   - go vet ./...

--- a/cmd/cacophony-config/main.go
+++ b/cmd/cacophony-config/main.go
@@ -16,6 +16,7 @@ type Args struct {
 	ConfigDir string   `arg:"-c,--config" help:"path to configuration directory"`
 	Write     bool     `arg:"-w,--write" help:"write to config file"`
 	Read      bool     `arg:"-r,--read" help:"read from the config file"`
+	Delete    bool     `arg:"-d,--delete" help:"delete from config file"`
 	Input     []string `arg:"positional"`
 }
 
@@ -47,7 +48,20 @@ func runMain() error {
 	if args.Read {
 		return readConfig(&args)
 	}
+	if args.Delete {
+		return deleteConfig(&args)
+	}
 	return errors.New("no valid arguments given")
+}
+
+func deleteConfig(args *Args) error {
+
+	_, err := config.New(args.ConfigDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func readConfig(args *Args) error {

--- a/cmd/cacophony-config/main.go
+++ b/cmd/cacophony-config/main.go
@@ -17,6 +17,7 @@ type Args struct {
 	Write     bool     `arg:"-w,--write" help:"write to config file"`
 	Read      bool     `arg:"-r,--read" help:"read from the config file"`
 	Delete    bool     `arg:"-d,--delete" help:"delete from config file"`
+	Force     bool     `arg:"-f,--force" help:"force writing to config if invalid keys are found"`
 	Input     []string `arg:"positional"`
 }
 
@@ -105,7 +106,7 @@ func writeNewSettings(args *Args) error {
 
 	sections := map[string]struct{}{}
 	for _, s := range settings {
-		if err := conf.SetField(s.section, s.field, s.value); err != nil {
+		if err := conf.SetField(s.section, s.field, s.value, args.Force); err != nil {
 			return err
 		}
 		sections[s.section] = struct{}{}

--- a/cmd/cacophony-config/main.go
+++ b/cmd/cacophony-config/main.go
@@ -8,6 +8,7 @@ import (
 
 	config "github.com/TheCacophonyProject/go-config"
 	"github.com/alexflint/go-arg"
+	"github.com/pelletier/go-toml"
 )
 
 var version = "<not set>"
@@ -76,11 +77,9 @@ func readConfig(args *Args) error {
 	}
 
 	for _, section := range args.Input {
-		var m map[string]interface{}
-		if err := conf.Unmarshal(section, &m); err != nil {
+		if err := printSection(section, conf); err != nil {
 			return err
 		}
-		log.Printf("section: '%s', values: '%s'", section, m)
 	}
 	return nil
 }
@@ -115,14 +114,25 @@ func writeNewSettings(args *Args) error {
 		return err
 	}
 
-	for section, _ := range sections {
-		raw := map[string]interface{}{}
-		if err := conf.Unmarshal(section, &raw); err != nil {
+	for section := range sections {
+		if err := printSection(section, conf); err != nil {
 			return err
 		}
-		log.Printf("section: '%s', values: '%s'", section, raw)
 	}
 
+	return nil
+}
+
+func printSection(section string, conf *config.Config) error {
+	var m map[string]interface{}
+	if err := conf.Unmarshal(section, &m); err != nil {
+		return err
+	}
+	t, err := toml.TreeFromMap(map[string]interface{}{section: m})
+	if err != nil {
+		return err
+	}
+	log.Println(t)
 	return nil
 }
 

--- a/cmd/cacophony-config/main.go
+++ b/cmd/cacophony-config/main.go
@@ -55,12 +55,16 @@ func runMain() error {
 }
 
 func deleteConfig(args *Args) error {
-
-	_, err := config.New(args.ConfigDir)
+	conf, err := config.New(args.ConfigDir)
 	if err != nil {
 		return err
 	}
-
+	for _, key := range args.Input {
+		if err := conf.Unset(key); err != nil {
+			return err
+		}
+		log.Printf("deleted '%s'", key)
+	}
 	return nil
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -268,6 +268,25 @@ func TestMapToLocation(t *testing.T) {
 	equalLocation(t, locationExpected, location)
 }
 
+func TestNotWritingZeroValues(t *testing.T) {
+	defer newFs(t, "")()
+	conf, err := New(DefaultConfigDir)
+	require.NoError(t, err)
+
+	newNow()
+	locationMap := map[string]interface{}{
+		"lAtitUde":  "123.321",
+		"TiMestamp": now().Format(TimeFormat),
+	}
+	locationMapExpected := map[string]interface{}{
+		"latitude":  float32(123.321),
+		"timestamp": now().Truncate(time.Second),
+		"updated":   now(),
+	}
+	require.NoError(t, conf.SetFromMap(LocationKey, locationMap, false))
+	require.Equal(t, locationMapExpected, (conf.v.AllSettings()[LocationKey]))
+}
+
 func TestMapToAudio(t *testing.T) {
 	defer newFs(t, "")()
 	conf, err := New(DefaultConfigDir)

--- a/config_test.go
+++ b/config_test.go
@@ -131,6 +131,21 @@ func TestReadingConfigInDir(t *testing.T) {
 	assert.Equal(t, audioChanges, audio)
 }
 
+func TestSettingInvalidKeys(t *testing.T) {
+	defer newFs(t, "")()
+	conf, err := New(DefaultConfigDir)
+	require.NoError(t, err)
+
+	w := randomWindows()
+	require.NoError(t, conf.Set(WindowsKey, w))
+	m := map[string]interface{}{
+		"invalid-key": "a value",
+	}
+	require.Error(t, conf.SetFromMap(WindowsKey, m, false))
+	require.NoError(t, conf.SetFromMap(WindowsKey, m, true))
+	require.Equal(t, "a value", conf.Get("windows.invalid-key"))
+}
+
 func TestWriting(t *testing.T) {
 	defer newFs(t, "")()
 	conf, err := New(DefaultConfigDir)
@@ -248,7 +263,7 @@ func TestMapToLocation(t *testing.T) {
 		Timestamp: now(),
 	}
 	var location Location
-	require.NoError(t, conf.SetFromMap(LocationKey, locationMap))
+	require.NoError(t, conf.SetFromMap(LocationKey, locationMap, false))
 	require.NoError(t, conf.Unmarshal(LocationKey, &location))
 	equalLocation(t, locationExpected, location)
 }
@@ -318,8 +333,8 @@ func TestSetField(t *testing.T) {
 	}
 	require.NoError(t, conf.Set(AudioKey, audio))
 
-	require.NoError(t, conf.SetField(AudioKey, "card", "5"))
-	require.Error(t, conf.SetField(AudioKey, "not-a-key", "5"))
+	require.NoError(t, conf.SetField(AudioKey, "card", "5", false))
+	require.Error(t, conf.SetField(AudioKey, "not-a-key", "5", false))
 
 	var audio2 Audio
 	require.NoError(t, conf.Unmarshal(AudioKey, &audio2))
@@ -339,7 +354,7 @@ func checkWritingMap(
 	s, expected interface{},
 	m map[string]interface{},
 	conf *Config) {
-	require.NoError(t, conf.SetFromMap(key, m))
+	require.NoError(t, conf.SetFromMap(key, m, false))
 	require.NoError(t, conf.Unmarshal(key, s))
 	require.Equal(t, expected, s)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -275,13 +275,11 @@ func TestNotWritingZeroValues(t *testing.T) {
 
 	newNow()
 	locationMap := map[string]interface{}{
-		"lAtitUde":  "123.321",
-		"TiMestamp": now().Format(TimeFormat),
+		"lAtitUde": "123.321",
 	}
 	locationMapExpected := map[string]interface{}{
-		"latitude":  float32(123.321),
-		"timestamp": now().Truncate(time.Second),
-		"updated":   now(),
+		"latitude": float32(123.321),
+		"updated":  now(),
 	}
 	require.NoError(t, conf.SetFromMap(LocationKey, locationMap, false))
 	require.Equal(t, locationMapExpected, (conf.v.AllSettings()[LocationKey]))

--- a/config_test.go
+++ b/config_test.go
@@ -163,6 +163,30 @@ func TestWriting(t *testing.T) {
 	require.Equal(t, h, h2)
 }
 
+func TestClearSection(t *testing.T) {
+	defer newFs(t, "")()
+	conf, err := New(DefaultConfigDir)
+	require.NoError(t, err)
+	log.Println()
+	l := randomLocation()
+	w := randomWindows()
+	require.NoError(t, conf.Set(LocationKey, &l))
+	require.NoError(t, conf.Set(WindowsKey, &w))
+	require.NoError(t, conf.Unset(LocationKey+".latitude"))
+	require.Error(t, conf.Unset(LocationKey+".latitude.foo"))
+	require.NoError(t, conf.Unset(LocationKey+".bar"))
+	conf, err = New(DefaultConfigDir)
+	require.NoError(t, err)
+	l2 := Location{}
+	require.NoError(t, conf.Unmarshal(LocationKey, &l2))
+
+	w2 := Windows{}
+	require.NoError(t, conf.Unmarshal(WindowsKey, &w2))
+	l.Latitude = 0
+	equalLocation(t, l, l2)
+	require.Equal(t, w, w2)
+}
+
 func TestClear(t *testing.T) {
 	defer newFs(t, "")()
 	conf, err := New(DefaultConfigDir)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pelletier/go-toml v1.2.0
 	github.com/spf13/afero v1.1.2
+	github.com/spf13/cast v1.3.0
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
 	github.com/wawandco/fako v0.0.0-20180828010250-c36a0bc97398


### PR DESCRIPTION
- Change formatting of config output when reading config with `cacophony-config`
- Can delete parts of config using `cacophony-config -d <section.key>`
- Can now write to invalid config sections with the use of `--force`
- Fixed writing zero values when writing to a partly filled out section